### PR TITLE
Fix xmake yaml.  Move off deprecated yaml artifacts task.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Build
       run:
-        xmake -w
+        xmake -w -y
 
     - name: Merge Qt Stuff
       run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,14 +59,14 @@ jobs:
 
     - name: Upload Windows Artifact
       if: matrix.os == 'windows-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: files
         path: buildZipped\\EasyAutoTracker-Windows.zip
 
     - name: Upload Linux Artifact
       if: matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: files
         path: buildZipped/EasyAutoTracker-Linux.zip
@@ -78,7 +78,7 @@ jobs:
 
     steps:
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: files
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,14 +61,14 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: actions/upload-artifact@v4
       with:
-        name: files
+        name: filesWindows
         path: buildZipped\\EasyAutoTracker-Windows.zip
 
     - name: Upload Linux Artifact
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v4
       with:
-        name: files
+        name: filesLinux
         path: buildZipped/EasyAutoTracker-Linux.zip
 
   create_release:
@@ -77,10 +77,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Download Artifacts
+    - name: Download Windows Artifacts
       uses: actions/download-artifact@v4
       with:
-        name: files
+        name: filesWindows
+        path: files
+
+    - name: Download Linux Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: filesLinux
+        path: files
 
     - name: Create Draft Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
- Fix the xmake command in the yaml build failing now that we use packages in xmake.
- Update github actions yaml to use v4 of the artifacts tasks, since v3 is deprecated now.