### PR TITLE
Add Game options concept.  Add Lufia 2 Two-Jelly-Kill option.

### DIFF
--- a/src/GameSetup.cpp
+++ b/src/GameSetup.cpp
@@ -2,9 +2,14 @@
 
 #include <nlohmann/json.hpp>
 
-const std::vector<GameSetupMode>& GameSetup::Entries()
+const std::vector<GameSetupMode>& GameSetup::GameModes()
 {
     return allModes;
+}
+
+std::vector<GameSetupOption>& GameSetup::GameOptions()
+{
+    return allOptions;
 }
 
 void GameSetup::StartWatching()
@@ -34,7 +39,7 @@ void GameSetup::CreateDebugWindow()
     allDebugWindows.emplace_back(std::move(debugWindow));
 }
 
-void GameSetup::AddGameMode(const std::string name, std::function<std::unique_ptr<UpdatableGameWindow>()> creator)
+void GameSetup::AddGameMode(const std::string &name, std::function<std::unique_ptr<UpdatableGameWindow>()> creator)
 {
     auto createAndStoreWindow = [this, name, creator]()
     {
@@ -44,6 +49,13 @@ void GameSetup::AddGameMode(const std::string name, std::function<std::unique_pt
     };
 
     allModes.emplace_back(GameSetupMode(name, createAndStoreWindow));
+}
+
+void GameSetup::AddGameBoolOption(const std::string &name, std::function<void(bool enabled)> optionChanged, bool initialState)
+{
+    allOptions.emplace_back(GameSetupOption(name, optionChanged));
+    allOptions.back().Enabled = initialState;
+    optionChanged(initialState);
 }
 
 void GameSetup::OnWatcherTimerUpdate()

--- a/src/GameSetup.h
+++ b/src/GameSetup.h
@@ -26,13 +26,28 @@ struct GameSetupMode
     std::function<UpdatableGameWindow*()> Creator;
 };
 
+struct GameSetupOption
+{
+    GameSetupOption() = default;
+    inline GameSetupOption(const std::string &name, std::function<void(bool enabled)> optionChanged)
+    {
+        Name = name;
+        OptionChanged = optionChanged;
+    }
+
+    std::string Name;
+    bool Enabled = false;
+    std::function<void(bool enabled)> OptionChanged;
+};
+
 class GameSetup
 {
 public:
     virtual ~GameSetup() = default;
 
     virtual std::string Name() const = 0;
-    virtual const std::vector<GameSetupMode>& Entries();
+    const std::vector<GameSetupMode>& GameModes();
+    std::vector<GameSetupOption>& GameOptions(); // note: non-const because the enabled state can mutate with user input
 
     virtual void StartWatching();
     std::function<void()> OnWatcherUpdate;
@@ -50,13 +65,15 @@ protected:
 
     virtual void OnWatcherTimerUpdate();
 
-    void AddGameMode(const std::string name, std::function<std::unique_ptr<UpdatableGameWindow>()> creator);
+    void AddGameMode(const std::string &name, std::function<std::unique_ptr<UpdatableGameWindow>()> creator);
+    void AddGameBoolOption(const std::string &name, std::function<void(bool enabled)> optionChanged, bool initialState);
 
 private:
     std::unique_ptr<QTimer> mainPollTimer;
     std::shared_ptr<GameWatcher> watcherToPoll;
 
     std::vector<GameSetupMode> allModes;
+    std::vector<GameSetupOption> allOptions;
 
     struct NormalWindow
     {

--- a/src/GameSpecific/Lufia2-GameSetup.cpp
+++ b/src/GameSpecific/Lufia2-GameSetup.cpp
@@ -109,8 +109,17 @@ namespace
             SetFlagState("OnNameSelect", ram.ReadInteger<uint8_t>(0x0009) == 49 && ram.ReadInteger<uint8_t>(0x000A) == 126 && ram.ReadInteger<uint32_t>(0x0011) == 0 && !inGruberix && !onTitleMenu);
             SetFlagState("ScreenFading", !(ram.ReadInteger<uint8_t>(0x0583) == 15 || (ram.ReadInteger<uint8_t>(0x0583) == 128 && ram.ReadInteger<uint8_t>(0x0581) != 0)));
 
-            int bestFloor = ram.ReadInteger<uint8_t>(0x0B75); //NOTE: This is the "best floor" from the scoreboard data, not the actual current floor!
-            SetIntegerState("BestFloor", bestFloor);
+            //int blueChestScoreboard = ram.ReadInteger<uint16_t>(0x0B6E); // may use these later...
+            //SetIntegerState("BlueChestScoreboard", blueChestScoreboard);
+            //int redChestScoreboard = ram.ReadInteger<uint16_t>(0x0B70);
+            //SetIntegerState("RedChestScoreboard", redChestScoreboard);
+
+            int jellyKillScoreboard = ram.ReadInteger<uint8_t>(0x0B74);
+            SetIntegerState("JellyKillScoreboard", jellyKillScoreboard); // not currently using this for logic because there's a slight delay after the killing blow before it increments
+
+            int bestFloorScoreboard = ram.ReadInteger<uint8_t>(0x0B75);
+            SetIntegerState("BestFloorScoreboard", bestFloorScoreboard);
+
             int floor = ram.ReadInteger<uint8_t>(0x1E696);
             if (floor > 1) // changes to 0 between floors
                 SetIntegerState("Floor", floor - 1);

--- a/src/GameSpecific/Lufia2-GameSetup.cpp
+++ b/src/GameSpecific/Lufia2-GameSetup.cpp
@@ -112,7 +112,6 @@ namespace
             uint16_t blobHpAfterCurrentAttack = ram.ReadInteger<uint16_t>(0x162C);
             SetIntegerState("BlobHP", blobHpAfterCurrentAttack);
             uint8_t blobAnimationState = ram.ReadInteger<uint8_t>(0x421d); // also has other values outside of the blob fight sometimes
-            SetIntegerState("BlobAnimationState", blobAnimationState);
             SetFlagState("BlobDeathAnimation", blobAnimationState == 31);
 
             uint64_t inGameHours = ram.ReadInteger<uint8_t>(0x0b4d);
@@ -217,6 +216,11 @@ Lufia2GameSetup::Lufia2GameSetup()
 
         return timerToReturn;
     });
+
+    AddGameBoolOption("Require Two Jelly Kills", [this](bool enabled)
+    {
+        
+    }, false);
 }
 
 std::unique_ptr<UpdatableGameWindow> Lufia2GameSetup::CreateTimerForFloorSets(const std::vector<std::tuple<int, int, std::string>> &floorSets)

--- a/src/MemoryWatchers/SnesMemory.cpp
+++ b/src/MemoryWatchers/SnesMemory.cpp
@@ -32,7 +32,11 @@ bool SnesMemory::TryLocateRam(std::function<uint64_t(uint8_t *start, uint8_t *en
 
         data->snesProcess = PCProcessMemory::FindProcess([](const std::string &processNameLower)
         {
-            return processNameLower.find("snes") != std::string::npos || processNameLower.find("higan") != std::string::npos || processNameLower.find("ares") != std::string::npos;
+            return processNameLower.find("snes") != std::string::npos ||
+                   processNameLower == "higan" ||
+                   processNameLower == "ares" ||
+                   processNameLower == "emuhawk" ||
+                   processNameLower == "retroarch";
         }, [&](const PCProcessMemory &process)
         {
             process.ScanMemory([&](uint8_t *start, uint8_t *end, uint64_t startAddress)

--- a/src/MemoryWatchers/SnesMemory.cpp
+++ b/src/MemoryWatchers/SnesMemory.cpp
@@ -7,7 +7,6 @@
 namespace
 {
     const uint32_t SnesRamSize = 128 * 1024;
-    const uint32_t SnesRomSize = 6 * 1024 * 1024;
 }
 
 struct SnesMemoryInternal

--- a/src/Widgets/NestedTimerWindow.cpp
+++ b/src/Widgets/NestedTimerWindow.cpp
@@ -213,11 +213,11 @@ void NestedTimerWindow::SetNameDisplayPrefix(const std::string &name, const std:
 {
     for (NestedTimer &nested : nestedTimers)
     {
-        if (nested.Name == name)
+        if (name.empty() || nested.Name == name)
         {
             nested.DisplayPrefix = prefix;
             nested.Label->setText(QString::fromStdString(nested.DisplayPrefix + nested.Name));
-            break;
+            return;
         }
     }
 }

--- a/src/Widgets/NestedTimerWindow.cpp
+++ b/src/Widgets/NestedTimerWindow.cpp
@@ -209,6 +209,19 @@ void NestedTimerWindow::SetFocusTimer(const std::string &name)
     }
 }
 
+void NestedTimerWindow::SetNameDisplayPrefix(const std::string &name, const std::string &prefix)
+{
+    for (NestedTimer &nested : nestedTimers)
+    {
+        if (nested.Name == name)
+        {
+            nested.DisplayPrefix = prefix;
+            nested.Label->setText(QString::fromStdString(nested.DisplayPrefix + nested.Name));
+            break;
+        }
+    }
+}
+
 void NestedTimerWindow::StopAllTimers()
 {
     if (!isTimerActivated)

--- a/src/Widgets/NestedTimerWindow.cpp
+++ b/src/Widgets/NestedTimerWindow.cpp
@@ -213,11 +213,10 @@ void NestedTimerWindow::SetNameDisplayPrefix(const std::string &name, const std:
 {
     for (NestedTimer &nested : nestedTimers)
     {
-        if (name.empty() || nested.Name == name)
+        if ((name.empty() || nested.Name == name) && prefix != nested.DisplayPrefix)
         {
             nested.DisplayPrefix = prefix;
             nested.Label->setText(QString::fromStdString(nested.DisplayPrefix + nested.Name));
-            return;
         }
     }
 }

--- a/src/Widgets/NestedTimerWindow.h
+++ b/src/Widgets/NestedTimerWindow.h
@@ -24,7 +24,7 @@ public:
     void AddNestedTimer(const std::string &name);
     void SetActiveTimer(const std::string &name);
     void SetFocusTimer(const std::string &name);
-    void SetNameDisplayPrefix(const std::string &name, const std::string &prefix);
+    void SetNameDisplayPrefix(const std::string &name, const std::string &prefix); // special behaviour: empty name implies all timers
     void StopAllTimers();
     void ResetAllTimers();
 

--- a/src/Widgets/NestedTimerWindow.h
+++ b/src/Widgets/NestedTimerWindow.h
@@ -24,6 +24,7 @@ public:
     void AddNestedTimer(const std::string &name);
     void SetActiveTimer(const std::string &name);
     void SetFocusTimer(const std::string &name);
+    void SetNameDisplayPrefix(const std::string &name, const std::string &prefix);
     void StopAllTimers();
     void ResetAllTimers();
 
@@ -51,6 +52,7 @@ private slots:
     struct NestedTimer
     {
         std::string Name;
+        std::string DisplayPrefix;
         bool Activated = false;
         bool Focused = false;
         bool Touched = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,8 @@ int main(int argc, char **argv)
         {
             QCheckBox *gameOptionBox = new QCheckBox();
             gameOptionBox->setText(QString::fromStdString(gameOption.Name));
-            gameOptionBox->setEnabled(true);
+            gameOptionBox->setEnabled(false);
+            gameOptionBox->setCheckState(gameOption.Enabled ? Qt::Checked : Qt::Unchecked);
 
             GameSetupOption *gameOptionPointer = &gameOption;
             QObject::connect(gameOptionBox, &QCheckBox::stateChanged, [=]()
@@ -212,6 +213,13 @@ int main(int argc, char **argv)
                     catch (const std::exception &ex)
                     {
                         QMessageBox::warning(&window, "Not Good", QString("Error restoring layout data: ") + ex.what());
+                    }
+
+                    for (QCheckBox *optionsBox : gameOptionCheckers)
+                    {
+                        auto optionIter = std::find_if(activeGame->GameOptions().begin(), activeGame->GameOptions().end(), [&](const auto &option) { return optionsBox->text().toStdString() == option.Name; });
+                        if (optionIter !=activeGame->GameOptions().end())
+                            optionsBox->setCheckState(optionIter->Enabled ? Qt::Checked : Qt::Unchecked);
                     }
                 }
             }
@@ -308,6 +316,9 @@ int main(int argc, char **argv)
 
         for (QPushButton *gameAutoButton : gameActionButtons)
             gameAutoButton->setEnabled(true);
+
+        for (QCheckBox *gameOptionBox : gameOptionCheckers)
+            gameOptionBox->setEnabled(true);
     };
 
     onDisableGameAuto = [&]()
@@ -323,6 +334,9 @@ int main(int argc, char **argv)
 
         for (QPushButton *gameAutoButton : gameActionButtons)
             gameAutoButton->setEnabled(false);
+
+        for (QCheckBox *gameOptionBox : gameOptionCheckers)
+            gameOptionBox->setEnabled(false);
 
         activeGameStatusLabel->setText("");
     };


### PR DESCRIPTION
- Add the concept of boolean "options" for games.
- Add a "Require Two Jelly Kills" option to Lufia 2 Ancient Cave.
  - Substantially augment and adjust the Lufia 2 state logic to support this.
